### PR TITLE
args.region is not used for lambda client

### DIFF
--- a/source/code/cli/scheduler_cli/scheduler_cli.py
+++ b/source/code/cli/scheduler_cli/scheduler_cli.py
@@ -110,7 +110,7 @@ def handle_command(args, command):
         lambda_resource = cloudformation_client.describe_stack_resource(
             StackName=args.stack, LogicalResourceId="Main").get("StackResourceDetail", None)
 
-        lambda_client = boto3.client("lambda")
+        lambda_client = _service_client("lambda", region=args.region)
 
         event = {
             "source": EVENT_SOURCE,


### PR DESCRIPTION
Hi, 

Currently, args.region is not used when a lambda client is created.
Therefore a lambda function in default environmental region is used.

`$ scheduler-cli describe-periods --stack TestSchedule --region us-east-1`
`$ An error occurred (ResourceNotFoundException) when calling the Invoke operation: Function not found: arn:aws:lambda:ap-northeast-1:xxxxxxxxxx:function:TestSchedule-InstanceSchedulerMain`

