### PR TITLE
Add KMS CreateGrant to IAM policy for encrypted EBS support

### DIFF
--- a/source/cloudformation/instance-scheduler-remote.template
+++ b/source/cloudformation/instance-scheduler-remote.template
@@ -94,7 +94,34 @@
                             ]
                         }]
                     }
-                }]
+                },
+                {
+                    "Effect": "Allow",
+                     "Action": [
+                         "kms:CreateGrant"
+                     ],
+                     "Resource": [
+                         {
+                             "Fn::Join": [
+                                 ":",
+                                     [
+                                         "arn:aws:kms",
+                                         {
+                                             "Ref": "AWS::Region"
+                                         },
+                                         {
+                                             "Ref": "AWS::AccountId"
+                                         },
+                                         "key/*"
+                                    ]
+                              ]
+                         } ],
+                     "Condition": {
+                         "Bool": {
+                             "kms:GrantIsForAWSResource": true
+                         }
+                     }
+                 }]
             }
         }
     },

--- a/source/cloudformation/instance-scheduler.template
+++ b/source/cloudformation/instance-scheduler.template
@@ -909,7 +909,34 @@
                                 }
                             ]
                         }
-                    }]
+                    },
+                    {
+                        "Effect": "Allow",
+                         "Action": [
+                             "kms:CreateGrant"
+                         ],
+                         "Resource": [
+                             {
+                                 "Fn::Join": [
+                                     ":",
+                                         [
+                                             "arn:aws:kms",
+                                             {
+                                                 "Ref": "AWS::Region"
+                                             },
+                                             {
+                                                 "Ref": "AWS::AccountId"
+                                             },
+                                             "key/*"
+                                        ]
+                                  ]
+                             } ],
+                         "Condition": {
+                             "Bool": {
+                                 "kms:GrantIsForAWSResource": true
+                             }
+                         }
+                     }]
                 }
             }
         },


### PR DESCRIPTION
Adds support for starting EC2 instances with encrypted EBS volumes attached.  Should be a fix for issue #38 