### PR TITLE
Replaced ECS with EC2 in description as ECS is currently not supported

### DIFF
--- a/deployment/instance-scheduler-remote.template
+++ b/deployment/instance-scheduler-remote.template
@@ -1,6 +1,6 @@
 {
     "AWSTemplateFormatVersion": "2010-09-09",
-    "Description": "ECS and RDS scheduler cross account role, version 2.2.2.0",
+    "Description": "EC2 and RDS scheduler cross account role, version 2.2.2.0",
     "Parameters": {
         "InstanceSchedulerAccount": {
             "Type": "String",

--- a/source/cloudformation/instance-scheduler-remote.template
+++ b/source/cloudformation/instance-scheduler-remote.template
@@ -1,6 +1,6 @@
 {
     "AWSTemplateFormatVersion": "2010-09-09",
-    "Description": "ECS and RDS scheduler cross account role, version %version%",
+    "Description": "EC2 and RDS scheduler cross account role, version %version%",
     "Parameters": {
         "InstanceSchedulerAccount": {
             "Type": "String",

--- a/source/cloudformation/instance-scheduler.template
+++ b/source/cloudformation/instance-scheduler.template
@@ -1419,7 +1419,7 @@
                     "Ref": "MemorySize"
                 },
                 "Timeout": 300,
-                "Description": "ECS and RDS instance scheduler, version %version%"
+                "Description": "EC2 and RDS instance scheduler, version %version%"
             },
             "DependsOn": [
                 "SchedulerPolicy",

--- a/source/code/schedulers/ec2_service.py
+++ b/source/code/schedulers/ec2_service.py
@@ -44,7 +44,7 @@ DEBUG_SELECTED_INSTANCE = "Selected ec2 instance {} in state ({})"
 
 class Ec2Service:
     """
-    Implements service start/stop/resize functions for ECS service
+    Implements service start/stop/resize functions for EC2 service
     """
     EC2_STATE_PENDING = 0
     EC2_STATE_RUNNING = 16


### PR DESCRIPTION
Modified the descriptions containing a reference to ECS.

ECS is not supported by the instance scheduler, so let's not refer to it in the description of the EC2 service related related sections.