### PR TITLE
Allow the Name parameter to be sent for a schedule definition.

### DIFF
--- a/source/code/requesthandlers/schedule_resource_handler.py
+++ b/source/code/requesthandlers/schedule_resource_handler.py
@@ -40,6 +40,7 @@ PROP_INSTANCE_TYPE = "InstanceType"
 PROP_METRICS = "Metrics"
 PROP_MONTH_DAYS = "MonthDays"
 PROP_MONTHS = "Months"
+PROP_NAME = "Name"
 PROP_OVERRIDE_STATUS = "OverrideStatus"
 PROP_OVERWRITE = "Overwrite"
 PROP_PERIODS = "Periods"
@@ -53,6 +54,7 @@ VALID_SCHEDULE_PROPERTIES = [
     PROP_DESCRIPTION,
     PROP_ENFORCED,
     PROP_METRICS,
+    PROP_NAME,
     PROP_OVERRIDE_STATUS,
     PROP_OVERWRITE,
     PROP_PERIODS,
@@ -112,7 +114,7 @@ class ScheduleResourceHandler(CustomResource):
 
     @property
     def _schedule_resource_name(self):
-        return "{}-{}".format(self.stack_name, self.logical_resource_id)
+        return self.resource_properties.get(PROP_NAME, "{}-{}".format(self.stack_name, self.logical_resource_id))
 
     def _create_period(self, period):
 


### PR DESCRIPTION
Allow the Name parameter to be sent for a schedule definition.  Use the Name property for the name of the Schedule, otherwise fall back to the previous functionality.

This addresses #71.  When I tested this it successfully created a schedule with the name passed in by the Name property.  From what I could tell this is all that needed to be changed, though I could be missing something.  I know you are getting ready to release a new version soon.  Hopefully this small change can be incorporated.