### PR TITLE
Fix exception handling unreferenced variable

### DIFF
--- a/source/code/schedulers/rds_service.py
+++ b/source/code/schedulers/rds_service.py
@@ -302,7 +302,7 @@ class RdsService:
                 if type(e).__name__ == "DBSnapshotNotFoundFault":
                     return False
                 else:
-                    raise ex
+                    raise e
 
         self._init_scheduler(kwargs)
 


### PR DESCRIPTION
Unreferenced variable ex should be 'e'. It was hiding actual exception on describe_db_shapshots_with_retries call

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
