### PR TITLE
Update instance scheduler cross account role 

### DIFF
--- a/source/cloudformation/instance-scheduler-remote.template
+++ b/source/cloudformation/instance-scheduler-remote.template
@@ -71,7 +71,11 @@
                             "Statement": [
                                 {
                                     "Effect": "Allow",
-                                    "Action": "rds:DeleteDBSnapshot",
+                                    "Action": [
+                                        "rds:DeleteDBSnapshot",
+                                        "rds:DescribeDBSnapshots",
+                                        "rds:StopDBInstance"
+                                    ],                                        
                                     "Resource": {
                                         "Fn::Join": [
                                             ":",

--- a/source/code/schedulers/rds_service.py
+++ b/source/code/schedulers/rds_service.py
@@ -345,12 +345,12 @@ class RdsService:
             snapshot_name = "{}-stopped-{}".format(self._stack_name, inst.id).replace(" ", "")
             args["DBSnapshotIdentifier"] = snapshot_name
 
-        try:
-            if does_snapshot_exist(snapshot_name):
-                client.delete_db_snapshot_with_retries(DBSnapshotIdentifier=snapshot_name)
-                self._logger.info(INF_DELETE_SNAPSHOT, snapshot_name)
-        except Exception as ex:
-            self._logger.error(ERR_DELETING_SNAPSHOT, snapshot_name)
+            try:
+                if does_snapshot_exist(snapshot_name):
+                    client.delete_db_snapshot_with_retries(DBSnapshotIdentifier=snapshot_name)
+                    self._logger.info(INF_DELETE_SNAPSHOT, snapshot_name)
+            except Exception as ex:
+                self._logger.error(ERR_DELETING_SNAPSHOT, snapshot_name)
     
         try:
             client.stop_db_instance_with_retries(**args)


### PR DESCRIPTION
*Issue #95 

*Description of changes:*

When using snapshots, both the DescribeDBSnaphot and StopDBInstance need to be applied to the snapshot resource also and not only to the rds resource


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
