### PR TITLE
Fix cron syntax in cloudformation template

### DIFF
--- a/source/lib/aws-instance-scheduler-stack.ts
+++ b/source/lib/aws-instance-scheduler-stack.ts
@@ -612,7 +612,7 @@ export class AwsInstanceSchedulerStack extends cdk.Stack {
     mappings.setValue("Timeouts", "10", "cron(0/10 * * * ? *)")
     mappings.setValue("Timeouts", "15", "cron(0/15 * * * ? *)")
     mappings.setValue("Timeouts", "30", "cron(0/30 * * * ? *)")
-    mappings.setValue("Timeouts", "60", "cron(0/1 * * ? *)")
+    mappings.setValue("Timeouts", "60", "cron(0 0/1 * * ? *)")
     mappings.setValue("Settings", "MetricsUrl", "https://metrics.awssolutionsbuilder.com/generic")
     mappings.setValue("Settings", "MetricsSolutionId", "S00030")
 


### PR DESCRIPTION
I recently tried to create a cloudformation stack using the latest template with the Frequency parameter set to 60, but the creation failed due to the error "Parameter ScheduleExpression is not valid."
To fix this issue, I fixed the cron syntax in the cloudformation template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.