### PR TITLE
Add DocumentDB support

### DIFF
--- a/source/lambda/configuration/config_admin.py
+++ b/source/lambda/configuration/config_admin.py
@@ -86,7 +86,7 @@ class ConfigAdmin:
     # regex for checking time formats H:MM and HH:MM
     TIME_REGEX = "^([0|1]?[0-9]|2[0-3]):[0-5][0-9]$"
 
-    SUPPORTED_SERVICES = ["ec2", "rds"]
+    SUPPORTED_SERVICES = ["ec2", "rds", "docdb"]
 
     class CustomEncoder(json.JSONEncoder):
         """

--- a/source/lambda/schedulers/__init__.py
+++ b/source/lambda/schedulers/__init__.py
@@ -12,6 +12,7 @@
 ######################################################################################################################
 from schedulers.ec2_service import Ec2Service
 from schedulers.rds_service import RdsService
+from schedulers.docdb_service import DocDbService
 
 INST_ALLOW_RESIZE = "allow_resize"
 INST_RESIZED = "resized"
@@ -55,7 +56,8 @@ PARAM_CLUSTERS = "clusters"
 
 SCHEDULER_TYPES = {
     "ec2": Ec2Service,
-    "rds": RdsService
+    "rds": RdsService,
+    "docdb": DocDbService
 }
 
 

--- a/source/lib/aws-instance-scheduler-stack.ts
+++ b/source/lib/aws-instance-scheduler-stack.ts
@@ -64,7 +64,7 @@ export class AwsInstanceSchedulerStack extends cdk.Stack {
     const scheduledServices = new cdk.CfnParameter(this, 'ScheduledServices', {
       description: 'Scheduled Services.',
       type: "String",
-      allowedValues: ["EC2", "RDS", "Both"],
+      allowedValues: ["EC2", "RDS", "DOCDB", "All"],
       default: "EC2"
     });
 
@@ -616,7 +616,8 @@ export class AwsInstanceSchedulerStack extends cdk.Stack {
     mappings.setValue("EnabledDisabled", "No", "DISABLED")
     mappings.setValue("Services", "EC2", "ec2")
     mappings.setValue("Services", "RDS", "rds")
-    mappings.setValue("Services", "Both", "ec2,rds")
+    mappings.setValue("Services", "DOCDB", "docdb")
+    mappings.setValue("Services", "All", "ec2,rds,docdb")
     mappings.setValue("Timeouts", "1", "cron(0/1 * * * ? *)")
     mappings.setValue("Timeouts", "2", "cron(0/2 * * * ? *)")
     mappings.setValue("Timeouts", "5", "cron(0/5 * * * ? *)")


### PR DESCRIPTION
Issue #222 

Description of changes:
Adding functionality to support the scheduling of DocDB resources. Updated rds_service to exclude DocDB resources as DocDB was implicitly included due to overlapping API calls.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.